### PR TITLE
Fix raspberry-pi-imager.rb SHA256

### DIFF
--- a/Casks/r/raspberry-pi-imager.rb
+++ b/Casks/r/raspberry-pi-imager.rb
@@ -1,6 +1,6 @@
 cask "raspberry-pi-imager" do
   version "1.8.5"
-  sha256 "55ee320bfc56c0a4d396bede83c7f2bd0b46582227ece2038872330ca6104f6e"
+  sha256 "154a101fd6cfeb0b92a1d53ccaba047a9cd7e2fddfef3988178952416e940681"
 
   url "https://github.com/raspberrypi/rpi-imager/releases/download/v#{version}/Raspberry.Pi.Imager.#{version}.dmg",
       verified: "github.com/raspberrypi/rpi-imager/"


### PR DESCRIPTION
The current checksum is correct for the image downloaded from https://downloads.raspberrypi.org/imager/imager_latest.dmg, but the download is from GitHub releases which has a different checksum.

I don't know where the mismatch comes from.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
